### PR TITLE
fix: redirect loop tied to referrer

### DIFF
--- a/app/controllers/web/auth.js
+++ b/app/controllers/web/auth.js
@@ -44,8 +44,6 @@ function parseReturnOrRedirectTo(ctx, next) {
   } else if (isSANB(ctx.query.redirect_to)) {
     // in case people had a typo, we should support redirect_to as well
     ctx.session.returnTo = ctx.query.redirect_to;
-  } else if (ctx.get('Referrer') && ctx.method === 'GET') {
-    ctx.session.returnTo = ctx.get('Referrer');
   }
 
   // prevents lad being used as a open redirect

--- a/yarn.lock
+++ b/yarn.lock
@@ -11526,7 +11526,7 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-"loose-envify@github:tomashanacek/loose-envify":
+loose-envify@tomashanacek/loose-envify:
   version "1.0.0"
   resolved "https://codeload.github.com/tomashanacek/loose-envify/tar.gz/274d08b592bab76b3a7ab099a669ccd1b4a7a34f"
   dependencies:


### PR DESCRIPTION
Revert recent addition to redirect logic based on referer can cause a redirect loop on register before the user is authenticated.