### PR TITLE
chore: update no password message

### DIFF
--- a/config/phrases.js
+++ b/config/phrases.js
@@ -99,7 +99,7 @@ module.exports = {
   PASSPORT_TOO_MANY_ATTEMPTS_ERROR:
     'Account is currently locked due to too many failed login attempts.  Please try again later.',
   PASSPORT_NO_SALT_VALUE_STORED_ERROR:
-    'Authentication is not possible.  No salt value was stored for the account.',
+    'Please log in with Google or GitHub and set your password in order to be able to log in with your email address.',
   PASSPORT_INCORRECT_PASSWORD_ERROR: 'Email address or password is incorrect.',
   PASSPORT_INCORRECT_USERNAME_ERROR: 'Email address or password is incorrect.',
   PASSPORT_MISSING_USERNAME_ERROR: 'Please enter an email address.',


### PR DESCRIPTION
Users who use Google or Github to sign up will not have an email / password setup on the backend. When that user tries to sign in with email / password they will therefore receive a message that password doesn't exist. We should provide a better message around this scenario to specify logging in with Google / Github and then managing password for the account once safely logged in.