### PR TITLE
Fix link in FAQ to ava repo

### DIFF
--- a/app/views/faq/index.md
+++ b/app/views/faq/index.md
@@ -1320,7 +1320,7 @@ Yes, absolutely.
 
 ## Is this well-tested
 
-Yes, it has tests written with [ava](https://github.com/avajs/ava/pull/2323) and also has code coverage.
+Yes, it has tests written with [ava](https://github.com/avajs/ava) and also has code coverage.
 
 
 ## Do you pass along SMTP response messages and codes


### PR DESCRIPTION
Hi there, apologies if this was intentional, but I noticed the `ava` link in the FAQ was linking to what looked like an unrelated PR in that repo, so this changes it to link to the repo itself instead