### PR TITLE
Remove .london TLD from bad domain list

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -348,7 +348,6 @@ const config = {
     '.jetzt',
     '.kim',
     '.loan',
-    '.london',
     '.life',
     '.live',
     '.men',


### PR DESCRIPTION
Hi there, I'm requesting that the `.london` domain be removed from the "bad domain" list, as it doesn't appear on any of the listings that are provided in the inline comment:

https://github.com/forwardemail/forwardemail.net/blob/fe659962728d5a3486cf8dff041082c4dd8d5ebe/config/index.js#L320-L325

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [ ] I have written a commit message that passes commitlint linting.
- [ ] I have ensured that my code changes pass linting tests.
- [ ] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

(made change on github, so will have to see if the above pass in CI)