### PR TITLE
fix: npm md link broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Follow the [Deployment](#deployment) guide below for automatic provisioning and 
 
 [namecheap]: https://namecheap.com
 
-[npm]: https//www.npmjs.com
+[npm]: https://www.npmjs.com
 
 [letsencrypt]: https://letsencrypt.org/
 


### PR DESCRIPTION
Forgot the colon in the hyperlink.