### PR TITLE
fix: allowed missing `dmarc.pct` which defaults to 100

### DIFF
--- a/app/controllers/web/my-account/retrieve-domain.js
+++ b/app/controllers/web/my-account/retrieve-domain.js
@@ -174,7 +174,7 @@ async function retrieveDomain(ctx, next) {
         (dmarcRecord?.v !== 'DMARC1' ||
           // !isSANB(dmarcRecord?.p) ||
           // !['none', 'reject', 'quarantine'].includes(dmarcRecord.p) ||
-          dmarcRecord?.pct !== 100)
+          (typeof dmarcRecord?.pct === "number" && dmarcRecord.pct !== 100))
       ) {
         ctx.state.isDMARCInvalid = true;
       }

--- a/app/models/domains.js
+++ b/app/models/domains.js
@@ -1297,7 +1297,7 @@ async function verifySMTP(domain, resolver, purgeCache = true) {
         if (
           dmarcRecord &&
           dmarcRecord.v === 'DMARC1' &&
-          dmarcRecord.pct === 100
+          (typeof dmarcRecord.pct !== "number" || dmarcRecord.pct === 100)
         ) {
           dmarc = true;
         }

--- a/config/phrases.js
+++ b/config/phrases.js
@@ -129,7 +129,7 @@ module.exports = {
   NO_REPLY_USERNAME_DISALLOWED:
     'You cannot use a "no-reply" username for an alias.',
   INVALID_DMARC_RESULT:
-    'Invalid DMARC result (policy must be <span class="notranslate">"p=none"</span>, <span class="notranslate">"p=reject"</span>, or <span class="notranslate">"p=quarantine"</span>, and <span class="notranslate">"pct=100"</span> must be set).',
+    'Invalid DMARC result (policy must be <span class="notranslate">"p=none"</span>, <span class="notranslate">"p=reject"</span>, or <span class="notranslate">"p=quarantine"</span>, and <span class="notranslate">"pct"</span> must be omitted or set to 100).',
   INVALID_SPF_RESULT: 'Invalid SPF result.',
   INVALID_DKIM_SIGNATURE: 'Invalid DKIM signature.',
   INVALID_FROM_HEADER:

--- a/helpers/process-email.js
+++ b/helpers/process-email.js
@@ -613,7 +613,7 @@ async function processEmail({ email, port = 25, resolver, client }) {
       // !['none', 'reject', 'quarantine'].includes(dmarc.policy) ||
       // dmarc?.policy !== 'reject' ||
       dmarc?.status?.result !== 'pass' ||
-      dmarc?.pct !== 100
+      (typeof dmarc?.pct === "number" && dmarc.pct !== 100)
     ) {
       const err = Boom.badRequest(i18n.translateError('INVALID_DMARC_RESULT'));
       if (dmarc) err.dmarc = dmarc;

--- a/test/smtp/index.js
+++ b/test/smtp/index.js
@@ -1715,7 +1715,7 @@ test('smtp outbound queue', async (t) => {
         'TXT',
         [
           // TODO: consume dmarc reports and parse dmarc-$domain
-          `v=DMARC1; p=reject; pct=100; rua=mailto:dmarc-${domain.id}@forwardemail.net;`
+          `v=DMARC1; p=reject; rua=mailto:dmarc-${domain.id}@forwardemail.net;`
         ],
         true
       )


### PR DESCRIPTION
According to [RFC 7489](https://datatracker.ietf.org/doc/html/rfc7489#section-6.3), `pct` is optional and defaults to 100. Current code reject DMARC records without `pct=100`, which is unnecessarily strict.

For example, `gmail.com` doesn't set `pct=100` for its DMARC. Cloudflare's DMARC generator also omit it by default.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
