### PR TITLE
fix: add missing webhook signature key in self hosted mode

### DIFF
--- a/config/meta.js
+++ b/config/meta.js
@@ -126,6 +126,10 @@ module.exports = function (config, isSitemap = false) {
       'Disposable Email Addresses for Custom Domains',
       'Get disposable email forwarding addresses using your custom domain name.'
     ],
+    '/self-hosted': [
+      'Self Hosted',
+      'Check out our complete self hosted setup.'
+    ],
     '/resources': [
       `Free Startup and Developer Email Tools List in <span class="notranslate">${dayjs(
         now

--- a/self-hosting/setup.sh
+++ b/self-hosting/setup.sh
@@ -457,6 +457,9 @@ generate_encryption_keys() {
   openssl genrsa -f4 -out "$SELF_HOST_DIR/ssl/dkim.key" 2048
   update_env_file "DKIM_PRIVATE_KEY_PATH" "/app/ssl/dkim.key"
 
+  webhook_signature_key=$(openssl rand -hex 16)
+  update_env_file "WEBHOOK_SIGNATURE_KEY" "$webhook_signature_key"
+
   echo "Helper, DKIM and SRS encryption keys generated."
 }
 


### PR DESCRIPTION
- fix missing webhook signature key generated for self hosted mode
- add /self-hosted to config/meta for seo