### PR TITLE
docs: cross link the self hosted documents

### DIFF
--- a/app/views/docs/self-hosted-solution/index.md
+++ b/app/views/docs/self-hosted-solution/index.md
@@ -86,6 +86,9 @@ The architecture includes containers for:
 * Redis for caching and performance
 * SQLite for secure, encrypted mailbox storage
 
+> \[!NOTE]
+> Be sure to check out our [self-hosted developer guide](https://forwardemail.net/self-hosted)
+
 ### Bash Script Installation: Accessibility Meets Security
 
 We've designed the installation process to be as simple as possible while maintaining security best practices:

--- a/app/views/self-hosted/index.md
+++ b/app/views/self-hosted/index.md
@@ -46,6 +46,9 @@ The architecture includes containers for:
 * Redis for caching and performance
 * SQLite for secure, encrypted mailbox storage
 
+> \[!NOTE]
+> Be sure to check out our [self-hosted blog](https://forwardemail.net/blog/docs/self-hosted-solution)
+
 
 ## Requirements
 

--- a/self-hosting/README.md
+++ b/self-hosting/README.md
@@ -25,6 +25,9 @@ This section documents the CI/CD workflow for ForwardEmail's self-hosted solutio
 
 ForwardEmail's self-hosted solution uses GitHub Actions to automatically build and publish Docker images whenever a new release is created. These images are then available for users to deploy on their own servers using the provided setup script.
 
+> \[!NOTE]
+> There is also our [self-hosted blog](https://forwardemail.net/blog/docs/self-hosted-solution) and [self-hosted developer guide](https://forwardemail.net/self-hosted)
+
 
 ## CI/CD Workflow
 


### PR DESCRIPTION
Cross linking https://forwardemail.net/en/blog/docs/self-hosted-solution and https://forwardemail.net/en/self-hosted