### PR TITLE
fix: API sorting and return created_at in response

### DIFF
--- a/app/controllers/api/v1/calendars.js
+++ b/app/controllers/api/v1/calendars.js
@@ -48,7 +48,7 @@ async function list(ctx) {
     {
       limit: ctx.query.limit,
       offset: ctx.paginate.skip,
-      sort: { created_at: -1 }
+      sort: { created_at: 'desc' }
     }
   );
 

--- a/app/controllers/api/v1/contacts.js
+++ b/app/controllers/api/v1/contacts.js
@@ -94,7 +94,7 @@ async function list(ctx) {
     {
       limit: ctx.query.limit,
       offset: ctx.paginate.skip,
-      sort: { created_at: -1 }
+      sort: { created_at: 'desc' }
     }
   );
 

--- a/app/controllers/api/v1/messages.js
+++ b/app/controllers/api/v1/messages.js
@@ -296,6 +296,9 @@ async function json(ctx, message) {
     // hdate -> header_date
     header_date: message.hdate,
 
+    // created_at (when the database record was created)
+    created_at: message.created_at,
+
     // subject
     subject: message.subject,
 
@@ -611,7 +614,7 @@ async function list(ctx) {
     ],
     limit: ctx.query.limit,
     offset: ctx.paginate.skip,
-    sort: { created_at: -1 }
+    sort: { created_at: 'desc' }
   };
 
   const sql = builder.build(opts);


### PR DESCRIPTION
```sh
Show the BUG (using -1):

node -e "const { Builder } = require('json-sql-enhanced'); const builder = new Builder(); const sql = builder.build({ type: 'select', table: 'Messages', fields: ['*'],
  limit: 10, offset: 0, sort: { created_at: -1 } }); console.log('SQL:', sql.query); console.log('Values:', JSON.stringify(sql.values));"

Output:
SQL: select * from "Messages" order by "created_at" -1 limit 10 offset 0
Values: {}

Show the FIX (using 'desc'):

node -e "const { Builder } = require('json-sql-enhanced'); const builder = new Builder(); const sql = builder.build({ type: 'select', table: 'Messages', fields: ['*'],
  limit: 10, offset: 0, sort: { created_at: 'desc' } }); console.log('SQL:', sql.query); console.log('Values:', JSON.stringify(sql.values));"

Output:
SQL: select * from "Messages" order by "created_at" desc limit 10 offset 0
Values: {}

Bonus: Test ascending order:

node -e "const { Builder } = require('json-sql-enhanced'); const builder = new Builder(); const sql = builder.build({ type: 'select', table: 'Messages', fields: ['*'],
  limit: 10, offset: 0, sort: { created_at: 'asc' } }); console.log('SQL:', sql.query);"

Output:
SQL: select * from "Messages" order by "created_at" asc limit 10 offset 0
```