### PR TITLE
feat: allow basic auth for outbound SMTP API

### DIFF
--- a/helpers/ensure-api-token-or-alias-auth.js
+++ b/helpers/ensure-api-token-or-alias-auth.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Forward Email LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+const Boom = require('@hapi/boom');
+const basicAuth = require('basic-auth');
+
+const policies = require('#helpers/policies');
+const aliasAuth = require('#controllers/api/v1/alias-auth');
+
+/**
+ * Dual authentication middleware that supports both API token and alias credentials
+ * - If password is empty/not provided: treats username as API token
+ * - If password is provided: treats username as alias email and validates with alias password
+ *
+ * @param {Object} ctx - Koa context
+ * @param {Function} next - Next middleware function
+ * @returns {Promise<void>}
+ */
+async function ensureApiTokenOrAliasAuth(ctx, next) {
+  const creds = basicAuth(ctx.req);
+
+  if (!creds || !creds.name) {
+    return ctx.throw(
+      Boom.unauthorized(
+        ctx.translate
+          ? ctx.translate('AUTHENTICATION_REQUIRED')
+          : 'Authentication required. Use either API token or alias credentials.'
+      )
+    );
+  }
+
+  // If password is empty/not provided, treat as API token
+  // (this maintains backward compatibility with existing API token auth)
+  if (!creds.pass || creds.pass === '') {
+    ctx.logger.debug('Using API token authentication');
+    return policies.ensureApiToken(ctx, next);
+  }
+
+  // If password is provided, treat as alias credentials
+  // (username should be in alias@domain.com format)
+  ctx.logger.debug('Using alias authentication', {
+    username: creds.name
+  });
+  return aliasAuth(ctx, next);
+}
+
+module.exports = ensureApiTokenOrAliasAuth;

--- a/routes/api/v1/index.js
+++ b/routes/api/v1/index.js
@@ -16,6 +16,7 @@ const { boolean } = require('boolean');
 const _ = require('#helpers/lodash');
 const api = require('#controllers/api');
 const config = require('#config');
+const ensureApiTokenOrAliasAuth = require('#helpers/ensure-api-token-or-alias-auth');
 const policies = require('#helpers/policies');
 const rateLimit = require('#helpers/rate-limit');
 const web = require('#controllers/web');
@@ -59,7 +60,7 @@ const router = new Router({
 
 router.post(
   '/emails',
-  policies.ensureApiToken,
+  ensureApiTokenOrAliasAuth,
   policies.checkVerifiedEmail,
   web.myAccount.ensureNotBanned,
   api.v1.enforcePaidPlan,


### PR DESCRIPTION
For our mailbox related APIs (including calendar / contacts) we use basic auth with alias email and generated password. For outbound emails API we use API token. We should allow basic auth as well with alias information to keep parity and make the experience much more seamless / simple especially for webmail and later integrations.

Current State

  The POST /v1/emails endpoint currently:
  - Uses policies.ensureApiToken middleware (routes/api/v1/index.js:62)
  - Only accepts API tokens via Basic Auth username field
  - Password field is ignored

Additional Considerations

  Permissions - Alias auth might need domain-level checks (currently in onAuth)
  From Address - With alias auth, you may want to auto-set the "from" field to the authenticated alias

  Important Note on Alias Auth Scope

  When using alias credentials, the authenticated user would be the alias owner, so you may need to add logic to:
  - Restrict "from" address to the authenticated alias
  - Ensure proper domain permissions
  - Handle multi-domain scenarios