### PR TITLE
feat: add calendar events / tasks API endpoints

### DIFF
--- a/app/controllers/api/v1/calendar-events.js
+++ b/app/controllers/api/v1/calendar-events.js
@@ -1,0 +1,329 @@
+/**
+ * Copyright (c) Forward Email LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+const Boom = require('@hapi/boom');
+const ObjectID = require('bson-objectid');
+const isSANB = require('is-string-and-not-blank');
+
+const Aliases = require('#models/aliases');
+const CalendarEvents = require('#models/calendar-events');
+const Calendars = require('#models/calendars');
+const i18n = require('#helpers/i18n');
+const setPaginationHeaders = require('#helpers/set-pagination-headers');
+const updateStorageUsed = require('#helpers/update-storage-used');
+
+function json(event) {
+  // Transform calendar event data for API response
+  const object = {
+    //
+    // NOTE: we use `eventId` vs `_id` since
+    //       CalDAV spec allows arbitrary ID's from clients
+    //
+    id: event.eventId,
+    calendar_id: event.calendar.calendarId || event.calendar.toString(),
+    component_type: event.componentType,
+    ical: event.ical,
+    deleted_at: event.deleted_at,
+    created_at: event.created_at,
+    updated_at: event.updated_at,
+    object: event.componentType === 'VTODO' ? 'calendar_task' : 'calendar_event'
+  };
+
+  return object;
+}
+
+async function list(ctx) {
+  // Validate calendar ID
+  if (!isSANB(ctx.params.calendar_id))
+    throw Boom.badRequest(ctx.translateError('CALENDAR_INVALID_ID'));
+
+  // Get the calendar first to ensure it exists and user has access
+  const calendar = await Calendars.findOne(ctx.instance, ctx.state.session, {
+    calendarId: ctx.params.calendar_id
+  });
+
+  if (!calendar) {
+    throw Boom.notFound(ctx.translateError('CALENDAR_DOES_NOT_EXIST'));
+  }
+
+  const query = {
+    calendar: calendar._id,
+    deleted_at: { $exists: false }
+  };
+
+  // Filter by component type if specified
+  if (ctx.query.component_type) {
+    if (!['VEVENT', 'VTODO'].includes(ctx.query.component_type.toUpperCase())) {
+      throw Boom.badRequest(
+        ctx.translateError('CALENDAR_EVENT_INVALID_COMPONENT_TYPE')
+      );
+    }
+
+    query.componentType = ctx.query.component_type.toUpperCase();
+  }
+
+  // Get calendar events with pagination
+  const { results: events, count: itemCount } =
+    await CalendarEvents.findAndCount(
+      ctx.instance,
+      ctx.state.session,
+      query,
+      {},
+      {
+        limit: ctx.query.limit,
+        offset: ctx.paginate.skip,
+        sort: { created_at: -1 }
+      }
+    );
+
+  // Populate calendar info for each event
+  for (const event of events) {
+    if (event.calendar && typeof event.calendar !== 'object') {
+      event.calendar = calendar;
+    }
+  }
+
+  const pageCount = Math.ceil(itemCount / ctx.query.limit);
+
+  // Set pagination headers
+  setPaginationHeaders(
+    ctx,
+    pageCount,
+    ctx.query.page,
+    events.length,
+    itemCount
+  );
+
+  ctx.body = Array.isArray(events) ? events.map((event) => json(event)) : [];
+}
+
+async function create(ctx) {
+  const { body } = ctx.request;
+
+  // Validate calendar ID
+  if (!isSANB(ctx.params.calendar_id))
+    throw Boom.badRequest(ctx.translateError('CALENDAR_INVALID_ID'));
+
+  // Validate required fields
+  if (!body.ical) {
+    throw Boom.badRequest(ctx.translateError('CALENDAR_EVENT_ICAL_REQUIRED'));
+  }
+
+  // Get the calendar first to ensure it exists and user has access
+  const calendar = await Calendars.findOne(ctx.instance, ctx.state.session, {
+    calendarId: ctx.params.calendar_id
+  });
+
+  if (!calendar) {
+    throw Boom.notFound(ctx.translateError('CALENDAR_DOES_NOT_EXIST'));
+  }
+
+  const eventId = body.event_id || new ObjectID().toString();
+
+  // Check if event already exists
+  const existingEvent = await CalendarEvents.findOne(
+    ctx.instance,
+    ctx.state.session,
+    { eventId, calendar: calendar._id }
+  );
+
+  if (existingEvent)
+    throw Boom.conflict(ctx.translateError('CALENDAR_EVENT_ALREADY_EXISTS'));
+
+  // check if over quota
+  const { isOverQuota } = await Aliases.isOverQuota(
+    {
+      id: ctx.state.session.user.alias_id,
+      domain: ctx.state.session.user.domain_id,
+      locale: ctx.locale
+    },
+    0,
+    ctx.client
+  );
+  if (isOverQuota)
+    throw Boom.forbidden(i18n.translate('IMAP_MAILBOX_OVER_QUOTA', ctx.locale));
+
+  const event = await CalendarEvents.create({
+    // db virtual helper
+    instance: ctx.instance,
+    session: ctx.state.session,
+
+    // eventId
+    eventId,
+
+    // calendar reference
+    calendar: calendar._id,
+
+    // ical data (validation happens in model)
+    ical: body.ical
+  });
+
+  // Populate calendar info
+  event.calendar = calendar;
+
+  ctx.body = json(event);
+
+  // Update storage in background (events contribute to storage usage)
+  updateStorageUsed(ctx.state.session.user.alias_id, ctx.client)
+    .then()
+    .catch((err) =>
+      ctx.logger.fatal(err, { event, session: ctx.state.session })
+    );
+}
+
+async function retrieve(ctx) {
+  // Validate calendar ID
+  if (!isSANB(ctx.params.calendar_id))
+    throw Boom.badRequest(ctx.translateError('CALENDAR_INVALID_ID'));
+
+  // Validate event ID
+  if (!isSANB(ctx.params.id))
+    throw Boom.badRequest(ctx.translateError('CALENDAR_EVENT_INVALID_ID'));
+
+  // Get the calendar first to ensure it exists and user has access
+  const calendar = await Calendars.findOne(ctx.instance, ctx.state.session, {
+    calendarId: ctx.params.calendar_id
+  });
+
+  if (!calendar) {
+    throw Boom.notFound(ctx.translateError('CALENDAR_DOES_NOT_EXIST'));
+  }
+
+  const event = await CalendarEvents.findOne(ctx.instance, ctx.state.session, {
+    eventId: ctx.params.id,
+    calendar: calendar._id,
+    deleted_at: { $exists: false }
+  });
+
+  if (!event) {
+    throw Boom.notFound(ctx.translateError('CALENDAR_EVENT_DOES_NOT_EXIST'));
+  }
+
+  // Populate calendar info
+  event.calendar = calendar;
+
+  ctx.body = json(event);
+}
+
+async function update(ctx) {
+  const { body } = ctx.request;
+
+  // Validate calendar ID
+  if (!isSANB(ctx.params.calendar_id))
+    throw Boom.badRequest(ctx.translateError('CALENDAR_INVALID_ID'));
+
+  // Validate event ID
+  if (!isSANB(ctx.params.id))
+    throw Boom.badRequest(ctx.translateError('CALENDAR_EVENT_INVALID_ID'));
+
+  // Get the calendar first to ensure it exists and user has access
+  const calendar = await Calendars.findOne(ctx.instance, ctx.state.session, {
+    calendarId: ctx.params.calendar_id
+  });
+
+  if (!calendar) {
+    throw Boom.notFound(ctx.translateError('CALENDAR_DOES_NOT_EXIST'));
+  }
+
+  const event = await CalendarEvents.findOne(ctx.instance, ctx.state.session, {
+    eventId: ctx.params.id,
+    calendar: calendar._id,
+    deleted_at: { $exists: false }
+  });
+
+  if (!event) {
+    throw Boom.notFound(ctx.translateError('CALENDAR_EVENT_DOES_NOT_EXIST'));
+  }
+
+  // check if over quota
+  const { isOverQuota } = await Aliases.isOverQuota(
+    {
+      id: ctx.state.session.user.alias_id,
+      domain: ctx.state.session.user.domain_id,
+      locale: ctx.locale
+    },
+    0,
+    ctx.client
+  );
+  if (isOverQuota)
+    throw Boom.forbidden(i18n.translate('IMAP_MAILBOX_OVER_QUOTA', ctx.locale));
+
+  // Update event field
+  if (body.ical !== undefined) {
+    event.ical = body.ical;
+  }
+
+  // Set db virtual helpers
+  event.instance = ctx.instance;
+  event.session = ctx.state.session;
+  event.isNew = false;
+
+  await event.save();
+
+  // Populate calendar info
+  event.calendar = calendar;
+
+  ctx.body = json(event);
+
+  // Update storage in background (event size may have changed)
+  updateStorageUsed(ctx.state.session.user.alias_id, ctx.client)
+    .then()
+    .catch((err) =>
+      ctx.logger.fatal(err, { event, session: ctx.state.session })
+    );
+}
+
+async function remove(ctx) {
+  // Validate calendar ID
+  if (!isSANB(ctx.params.calendar_id))
+    throw Boom.badRequest(ctx.translateError('CALENDAR_INVALID_ID'));
+
+  // Validate event ID
+  if (!isSANB(ctx.params.id))
+    throw Boom.badRequest(ctx.translateError('CALENDAR_EVENT_INVALID_ID'));
+
+  // Get the calendar first to ensure it exists and user has access
+  const calendar = await Calendars.findOne(ctx.instance, ctx.state.session, {
+    calendarId: ctx.params.calendar_id
+  });
+
+  if (!calendar) {
+    throw Boom.notFound(ctx.translateError('CALENDAR_DOES_NOT_EXIST'));
+  }
+
+  const event = await CalendarEvents.findOne(ctx.instance, ctx.state.session, {
+    eventId: ctx.params.id,
+    calendar: calendar._id,
+    deleted_at: { $exists: false }
+  });
+
+  if (!event) {
+    throw Boom.notFound(ctx.translateError('CALENDAR_EVENT_DOES_NOT_EXIST'));
+  }
+
+  await CalendarEvents.deleteOne(ctx.instance, ctx.state.session, {
+    _id: event._id
+  });
+
+  // Populate calendar info
+  event.calendar = calendar;
+
+  ctx.body = json(event);
+
+  // Update storage in background (event was deleted, reducing storage usage)
+  updateStorageUsed(ctx.state.session.user.alias_id, ctx.client)
+    .then()
+    .catch((err) =>
+      ctx.logger.fatal(err, { event, session: ctx.state.session })
+    );
+}
+
+module.exports = {
+  list,
+  create,
+  retrieve,
+  update,
+  remove
+};

--- a/app/controllers/api/v1/index.js
+++ b/app/controllers/api/v1/index.js
@@ -6,6 +6,7 @@
 const aliases = require('./aliases');
 const aliasAuth = require('./alias-auth');
 const apple = require('./apple');
+const calendarEvents = require('./calendar-events');
 const calendars = require('./calendars');
 const contacts = require('./contacts');
 const domains = require('./domains');
@@ -31,6 +32,7 @@ module.exports = {
   aliases,
   aliasAuth,
   apple,
+  calendarEvents,
   calendars,
   contacts,
   domains,

--- a/assets/api-spec.json
+++ b/assets/api-spec.json
@@ -555,6 +555,90 @@
           }
         }
       },
+      "CalendarEvent": {
+        "type": "object",
+        "required": [
+          "id",
+          "calendar_id",
+          "component_type",
+          "ical",
+          "created_at",
+          "updated_at",
+          "object"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Event ID (eventId from CalDAV)"
+          },
+          "calendar_id": {
+            "type": "string",
+            "description": "Calendar ID this event belongs to"
+          },
+          "component_type": {
+            "type": "string",
+            "enum": ["VEVENT", "VTODO"],
+            "description": "Component type: VEVENT for calendar events, VTODO for tasks"
+          },
+          "ical": {
+            "type": "string",
+            "description": "Complete iCalendar (ICS) format string containing the event or task data"
+          },
+          "deleted_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Deletion timestamp (null if not deleted)"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "object": {
+            "type": "string",
+            "enum": ["calendar_event", "calendar_task"],
+            "description": "Object type: calendar_event for VEVENT, calendar_task for VTODO"
+          }
+        },
+        "example": {
+          "id": "event-123",
+          "calendar_id": "calendar-456",
+          "component_type": "VEVENT",
+          "ical": "BEGIN:VCALENDAR\\nVERSION:2.0\\nPRODID:-//forwardemail.net//caldav//EN\\nBEGIN:VEVENT\\nUID:event-123\\nDTSTART:20250115T140000Z\\nDTEND:20250115T150000Z\\nSUMMARY:Team Meeting\\nEND:VEVENT\\nEND:VCALENDAR",
+          "deleted_at": null,
+          "created_at": "2025-01-15T12:00:00.000Z",
+          "updated_at": "2025-01-15T12:00:00.000Z",
+          "object": "calendar_event"
+        }
+      },
+      "CalendarEventInput": {
+        "type": "object",
+        "required": ["ical"],
+        "properties": {
+          "ical": {
+            "type": "string",
+            "description": "Complete iCalendar (ICS) format string containing either a VEVENT (event) or VTODO (task) component. Must be valid according to RFC 5545."
+          },
+          "event_id": {
+            "type": "string",
+            "description": "Custom event ID (if not provided, will be auto-generated)"
+          }
+        }
+      },
+      "CalendarEventUpdateInput": {
+        "type": "object",
+        "required": ["ical"],
+        "properties": {
+          "ical": {
+            "type": "string",
+            "description": "Updated complete iCalendar (ICS) format string. Must contain the same component type (VEVENT or VTODO) as the original event."
+          }
+        }
+      },
       "Folder": {
         "type": "object",
         "required": [
@@ -2163,6 +2247,34 @@
         "schema": {
           "type": "string"
         }
+      },
+      "calendarEventCalendarId": {
+        "name": "calendar_id",
+        "in": "path",
+        "required": true,
+        "description": "Calendar ID",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "calendarEventId": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Calendar Event or Task ID",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "componentType": {
+        "name": "component_type",
+        "in": "query",
+        "required": false,
+        "description": "Filter by component type: VEVENT for calendar events, VTODO for tasks",
+        "schema": {
+          "type": "string",
+          "enum": ["VEVENT", "VTODO"]
+        }
       }
     },
     "responses": {
@@ -2912,6 +3024,299 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Calendar"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/calendars/{calendar_id}/events": {
+      "get": {
+        "tags": [
+          "Calendar Events"
+        ],
+        "summary": "List calendar events and tasks",
+        "description": "Retrieve a list of all calendar events (VEVENT) and tasks (VTODO) for a specific calendar. This endpoint supports pagination and filtering by component type.",
+        "operationId": "listCalendarEvents",
+        "security": [
+          {
+            "AliasAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/calendarEventCalendarId"
+          },
+          {
+            "$ref": "#/components/parameters/page"
+          },
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/componentType"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Calendar events retrieved successfully",
+            "headers": {
+              "X-Page-Count": {
+                "description": "Total number of pages",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "X-Page-Current": {
+                "description": "Current page number",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Number of items on current page",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "X-Item-Count": {
+                "description": "Total number of items",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CalendarEvent"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Calendar Events"
+        ],
+        "summary": "Create calendar event or task",
+        "description": "Create a new calendar event (VEVENT) or task (VTODO) in the specified calendar. The component type is automatically detected from the iCalendar data provided.",
+        "operationId": "createCalendarEvent",
+        "security": [
+          {
+            "AliasAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/calendarEventCalendarId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CalendarEventInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Calendar event created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CalendarEvent"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/calendars/{calendar_id}/events/{id}": {
+      "get": {
+        "tags": [
+          "Calendar Events"
+        ],
+        "summary": "Retrieve calendar event or task",
+        "description": "Retrieve a specific calendar event or task by its ID. Returns the complete event data including the iCalendar format string.",
+        "operationId": "retrieveCalendarEvent",
+        "security": [
+          {
+            "AliasAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/calendarEventCalendarId"
+          },
+          {
+            "$ref": "#/components/parameters/calendarEventId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Calendar event retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CalendarEvent"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Calendar Events"
+        ],
+        "summary": "Update calendar event or task",
+        "description": "Update an existing calendar event or task. You must provide the complete updated iCalendar data. The component type (VEVENT or VTODO) must remain the same as the original.",
+        "operationId": "updateCalendarEvent",
+        "security": [
+          {
+            "AliasAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/calendarEventCalendarId"
+          },
+          {
+            "$ref": "#/components/parameters/calendarEventId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CalendarEventUpdateInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Calendar event updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CalendarEvent"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Calendar Events"
+        ],
+        "summary": "Delete calendar event or task",
+        "description": "Delete a specific calendar event or task permanently. This action cannot be undone.",
+        "operationId": "deleteCalendarEvent",
+        "security": [
+          {
+            "AliasAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/calendarEventCalendarId"
+          },
+          {
+            "$ref": "#/components/parameters/calendarEventId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Calendar event deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CalendarEvent"
                 }
               }
             }

--- a/config/phrases.js
+++ b/config/phrases.js
@@ -821,6 +821,13 @@ module.exports = {
   CALENDAR_NAME_REQUIRED: 'Calendar name is required.',
   CALENDAR_INVALID_ID: 'Invalid calendar ID.',
 
+  CALENDAR_EVENT_ICAL_REQUIRED: 'Calendar event iCal data is required.',
+  CALENDAR_EVENT_ALREADY_EXISTS: 'Calendar event already exists with this ID.',
+  CALENDAR_EVENT_INVALID_ID: 'Invalid calendar event ID.',
+  CALENDAR_EVENT_DOES_NOT_EXIST: 'Calendar event does not exist.',
+  CALENDAR_EVENT_INVALID_COMPONENT_TYPE:
+    'Invalid component type. Must be either VEVENT or VTODO.',
+
   FOLDER_NAME_OR_PATH_REQUIRED: 'Folder must have either name or path.',
   FOLDER_INVALID_ID: 'Invalid folder ID.',
   FOLDER_DOES_NOT_EXIST: 'Folder does not exist.',

--- a/routes/api/v1/index.js
+++ b/routes/api/v1/index.js
@@ -521,6 +521,19 @@ router
   .put('/calendars/:id', api.v1.calendars.update)
   .delete('/calendars/:id', api.v1.calendars.remove);
 
+// calendar events and tasks (CalDAV)
+router
+  .use('/calendars/:calendar_id/events', api.v1.aliasAuth)
+  .get(
+    '/calendars/:calendar_id/events',
+    paginate.middleware(25, 100),
+    api.v1.calendarEvents.list
+  )
+  .post('/calendars/:calendar_id/events', api.v1.calendarEvents.create)
+  .get('/calendars/:calendar_id/events/:id', api.v1.calendarEvents.retrieve)
+  .put('/calendars/:calendar_id/events/:id', api.v1.calendarEvents.update)
+  .delete('/calendars/:calendar_id/events/:id', api.v1.calendarEvents.remove);
+
 // messages (IMAP/POP3)
 router
   .use('/messages', api.v1.aliasAuth)


### PR DESCRIPTION
Added missing calendar events API to interact with calendars via webmail

Schemas Added (lines 558-641):
  - CalendarEvent - Response schema with all event/task properties
  - CalendarEventInput - Request schema for creating events
  - CalendarEventUpdateInput - Request schema for updating events

Parameters Added (lines 2251-2278):
  - calendarEventCalendarId - Path parameter for calendar ID
  - calendarEventId - Path parameter for event/task ID
  - componentType - Query parameter for filtering by VEVENT/VTODO

Paths Added (lines 3046-3338):
  - GET /v1/calendars/{calendar_id}/events - List with pagination
  - POST /v1/calendars/{calendar_id}/events - Create
  - GET /v1/calendars/{calendar_id}/events/{id} - Retrieve
  - PUT /v1/calendars/{calendar_id}/events/{id} - Update
  - DELETE /v1/calendars/{calendar_id}/events/{id} - Delete