### PR TITLE
Security: Missing Authorization Check in ensureTeamPlan Middleware

### DIFF
--- a/app/controllers/web/my-account/ensure-team-plan.js
+++ b/app/controllers/web/my-account/ensure-team-plan.js
@@ -4,7 +4,8 @@
  */
 
 function ensureTeamPlan(ctx, next) {
-  ctx.state.isTeamPlanRequired = ctx.state.domain.plan !== 'team';
+  if (ctx.state.domain.plan !== 'team')
+    throw Boom.paymentRequired(ctx.translateError('TEAM_PLAN_REQUIRED'));
   return next();
 }
 


### PR DESCRIPTION
## Summary

Security: Missing Authorization Check in ensureTeamPlan Middleware

## Problem

**Severity**: `High` | **File**: `app/controllers/web/my-account/ensure-team-plan.js:L6`

The `ensureTeamPlan` middleware sets `ctx.state.isTeamPlanRequired` based on whether the domain plan is 'team', but it does NOT enforce any restriction. The variable name suggests it should block non-team plans, yet it always calls `next()`. This is likely a logic bug where the developer intended to check if team plan is required and throw an error if not met, but instead only sets a boolean flag without enforcement.

## Solution

Add proper authorization logic. If the intent is to require a team plan, throw an error when `ctx.state.domain.plan !== 'team'`. If the intent is just to set a flag for downstream use, rename the variable to avoid confusion. Current implementation: `ctx.state.isTeamPlanRequired = ctx.state.domain.plan !== 'team';` should likely be: `if (ctx.state.domain.plan !== 'team') throw Boom.paymentRequired(ctx.translateError('TEAM_PLAN_REQUIRED'));`

## Changes

- `app/controllers/web/my-account/ensure-team-plan.js` (modified)