### PR TITLE
test(sieve): failing tests for RFC 5703 mime bugs (header :mime wrong header, replace dropped, exists :mime parse error)

### DIFF
--- a/test/sieve/engine.js
+++ b/test/sieve/engine.js
@@ -2002,5 +2002,121 @@ describe('Core Sieve tests (RFC 5228 Section 5)', () => {
         assert.strictEqual(result.variables.depth, '3');
       });
     });
+
+    describe('header :mime structured access (RFC 5703 Section 4.1)', () => {
+      // These tests use `discard` (not `keep`) as the observable action
+      // inside the `if` block: Sieve applies an *implicit* keep whenever no
+      // other terminating action ran, so asserting on a 'keep' action would
+      // false-pass even if the condition never matched. `discard` only ever
+      // appears if the condition actually evaluated true.
+      it('should read :type from Content-Disposition when that header is requested, not Content-Type', async () => {
+        const script = `
+          require "mime";
+          foreverypart {
+            if header :mime :type :is "Content-Disposition" "inline" {
+              discard;
+            }
+          }
+        `;
+        const message = createMimeMessage([
+          {
+            contentType: 'image/png',
+            headers: {
+              'content-disposition': 'inline; filename="image.png"'
+            },
+            body: 'binarydata',
+            encoding: 'base64',
+            charset: false
+          }
+        ]);
+        const result = await executeScript(script, message);
+        assert.ok(!result.error);
+
+        // Content-Disposition is "inline", so per RFC 5703 4.1 :type on that
+        // header should evaluate to "inline" and this test should match.
+        // Currently getMimeStructuredValue() ignores the requested header
+        // name and always parses `part.contentType` ("image/png") instead,
+        // so :type evaluates to "image" and this never matches.
+        assert.ok(
+          result.actions.some((a) => a.type === 'discard'),
+          'expected :type on "Content-Disposition" to read the disposition ' +
+            '("inline"), but the engine always parses Content-Type regardless ' +
+            'of which header was requested'
+        );
+      });
+
+      it('should return blank (not Content-Type) for :type on a header that has no type/subtype concept', async () => {
+        const script = `
+          require "mime";
+          foreverypart {
+            if header :mime :type :is "Content-ID" "" {
+              discard;
+            }
+          }
+        `;
+        const message = createMimeMessage([
+          {
+            contentType: 'image/png',
+            headers: {
+              'content-id': '<abc123@example.com>'
+            },
+            body: 'binarydata',
+            encoding: 'base64',
+            charset: false
+          }
+        ]);
+        const result = await executeScript(script, message);
+        assert.ok(!result.error);
+
+        // Per RFC 5703 4.1: "for other MIME headers, uses a blank string for
+        // the test" - :type on Content-ID (which has no type/subtype) should
+        // be "". Currently it evaluates to "image" (from part.contentType)
+        // instead, so this never matches either.
+        assert.ok(
+          result.actions.some((a) => a.type === 'discard'),
+          'expected :type on "Content-ID" to be blank per RFC 5703 4.1, but ' +
+            'the engine returns the Content-Type major type instead'
+        );
+      });
+
+      it('should read :param from Content-Disposition when that header is requested, not Content-Type', async () => {
+        const script = `
+          require "mime";
+          foreverypart {
+            if header :mime :param "filename" :matches "Content-Disposition" "image*.png" {
+              discard;
+            }
+          }
+        `;
+        const message = createMimeMessage([
+          {
+            // Deliberately different filename in Content-Type's "name" vs.
+            // Content-Disposition's "filename" param, so the test can only
+            // pass if :param actually reads from Content-Disposition.
+            contentType: 'image/png; name="not-this-one.txt"',
+            headers: {
+              'content-type': 'image/png; name="not-this-one.txt"',
+              'content-disposition': 'inline; filename="image001.png"'
+            },
+            body: 'binarydata',
+            encoding: 'base64',
+            charset: false
+          }
+        ]);
+        const result = await executeScript(script, message);
+        assert.ok(!result.error);
+
+        // getMimeStructuredValue()'s 'param' branch unconditionally reads
+        // part.headers['content-type'], regardless of which header name was
+        // passed to :param. So this currently fails to find "filename" on
+        // Content-Disposition at all.
+        assert.ok(
+          result.actions.some((a) => a.type === 'discard'),
+          'expected :param "filename" to read from the requested header ' +
+            '(Content-Disposition), but the engine always reads Content-Type\'s ' +
+            'parameters instead'
+        );
+      });
+    });
   });
 });

--- a/test/sieve/filter-handler.js
+++ b/test/sieve/filter-handler.js
@@ -192,6 +192,44 @@ describe('Sieve Filter Handler', () => {
       assert.strictEqual(applied.headerChanges.length, 1);
       assert.strictEqual(applied.kept, true);
     });
+
+    it('should handle replace action (RFC 5703) - currently silently dropped', async () => {
+      const result = {
+        actions: [
+          {
+            type: 'replace',
+            partIndex: 0,
+            replacement: 'New content',
+            mime: false,
+            subject: null,
+            from: null
+          }
+        ]
+      };
+      const applied = await handler.applyActions(result, createMessage());
+
+      // applyActions() currently has no `case 'replace'` at all (compare to
+      // the 'addheader'/'deleteheader' cases just above it, which populate
+      // `applied.headerChanges`), so nothing on `applied` reflects that a
+      // replace action was even present. The `partReplacements` shape below
+      // mirrors the existing pattern for addheader/deleteheader - it
+      // documents the missing behavior rather than prescribing the exact
+      // contract. This should fail until 'replace' is handled.
+      assert.ok(
+        Array.isArray(applied.partReplacements) &&
+          applied.partReplacements.length === 1,
+        'expected applyActions() to record MIME part replacements from a ' +
+          "replace action, but the action type is not handled at all - it's " +
+          'silently dropped'
+      );
+      if (Array.isArray(applied.partReplacements)) {
+        assert.strictEqual(applied.partReplacements[0].partIndex, 0);
+        assert.strictEqual(
+          applied.partReplacements[0].replacement,
+          'New content'
+        );
+      }
+    });
   });
 
   describe('Vacation handling', () => {

--- a/test/sieve/parser.js
+++ b/test/sieve/parser.js
@@ -567,6 +567,30 @@ describe('Sieve Parser - MIME Commands (RFC 5703)', () => {
     assert.ok(ifCmd.test.mime);
   });
 
+  it('should parse exists test with :mime tag (RFC 5703 Section 4.3)', () => {
+    const script =
+      'require "mime"; foreverypart { if exists :mime "Content-ID" { discard; } }';
+
+    // Currently throws:
+    //   Sieve syntax error at line 1, column X: Expected "#", ")", ",",
+    //   "/*", or [ \t\n\r] but "\"" found.
+    // The grammar's `exists` rule lacks a `:mime` branch, even though
+    // `header` (see 'should parse header test with :mime tag' above)
+    // supports it. Per RFC 5703 4.3:
+    //   Usage: exists [":mime"] [":anychild"] <header-names: string-list>
+    const ast = parse(script);
+    const fep = ast.commands.find((c) => c.type === 'Foreverypart');
+    assert.ok(fep);
+    const ifCmd = fep.block[0];
+    assert.strictEqual(ifCmd.type, 'If');
+    assert.strictEqual(ifCmd.test.type, 'ExistsTest');
+    assert.ok(
+      ifCmd.test.mime,
+      'expected exists test to accept :mime like header/address do'
+    );
+    assert.deepStrictEqual(ifCmd.test.headers, ['Content-ID']);
+  });
+
   it('should parse header test with :type tag', () => {
     const script =
       'require "mime"; foreverypart { if header :mime :type :is "content-type" "text" { discard; } }';


### PR DESCRIPTION
## Summary

Failing tests demonstrating the three RFC 5703 (`foreverypart`/`mime`) bugs reported in #548 — **these are reproductions, not fixes**. I'm not confident enough in the engine/grammar internals to safely fix `engine.js`/`grammar.pegjs` myself, so this PR pins down the behavior at the unit level for whoever does (happy to help iterate).

- `test/sieve/engine.js` — 3 tests: `header :mime :type`/`:param` always parse `Content-Type` regardless of which header the script names (`getMimeStructuredValue()` never receives the header name). Per RFC 5703 §4.1, `:type` on `Content-Disposition` must test the disposition value, and headers with no type concept must test blank. The tests assert on an explicit `discard` rather than `keep`, since the implicit keep would false-pass.
- `test/sieve/filter-handler.js` — 1 test: the `replace` action record produced by `executeReplace()` has no consumer in `applyActions()` (or anywhere else), so it's silently dropped. The asserted `partReplacements` shape mirrors the existing `headerChanges` pattern; it documents the gap rather than prescribing the contract.
- `test/sieve/parser.js` — 1 test: `exists :mime "Content-ID"` fails to parse; the grammar's `ExistsTest` rule lacks the `:mime`/`:anychild` tagged arguments defined in RFC 5703 §4.3, though `header :mime` parses fine.

## Test results

Run: `node --test test/sieve/engine.js test/sieve/filter-handler.js test/sieve/parser.js`

- 204 tests total: the 5 new tests fail (as intended, demonstrating the bugs), all 199 pre-existing tests still pass — pure additions, nothing else regresses.

See #548 for full analysis, RFC citations, and reproduction against the hosted service.
