### PR TITLE
test(sieve): failing tests for RFC 5703 capability registration, capability enforcement, and folded-boundary replace

### DIFF
--- a/test/sieve/engine.js
+++ b/test/sieve/engine.js
@@ -2120,20 +2120,27 @@ describe('Core Sieve tests (RFC 5228 Section 5)', () => {
     });
 
     describe('capability enforcement at execution time', () => {
-      it('should reject foreverypart/replace used without being required', async () => {
-        // RFC 5703 Sections 3 and 5 require that "foreverypart" and "replace"
-        // be declared in a require statement before the commands are used.
-        // Capability enforcement here happens only in processRequires(), which
-        // walks the strings literally listed in require; the command dispatch
-        // for foreverypart and replace has no hasCapability() guard at all.
-        // So omitting the declaration - which is what a script must do today
-        // to avoid the "Unsupported capability" rejection, since those strings
-        // are registered nowhere - lets the commands run anyway.
+      it('should reject foreverypart/replace used with no require statement', async () => {
+        // Capability enforcement happens only in processRequires(), which walks
+        // the strings literally listed in require; the command dispatch for
+        // foreverypart and replace has no hasCapability() guard at all. A
+        // script with no require statement whatsoever therefore executes both
+        // commands regardless.
         //
-        // The two failures are inverses of each other: a spec-compliant script
-        // is rejected, while this spec-violating one is accepted.
+        // This deliberately uses NO require statement rather than
+        // `require "mime"`, to stay neutral on an open question: RFC 5703
+        // defines distinct capability strings per command (foreverypart is
+        // Section 3, replace is Section 5), but this codebase's own tests
+        // consistently drive foreverypart behind `require "mime"` alone, and
+        // the FAQ documents all five commands under a single mime entry. So
+        // whether `require "mime"` should be sufficient is a design decision
+        // for the maintainers. A script with no require at all is invalid
+        // under either reading, which is what this test pins down.
+        //
+        // Paired with the require-time test in test/sieve/filter-handler.js,
+        // the two failures are inverses: a script that declares these
+        // extensions is rejected, while this one that declares nothing runs.
         const script = `
-          require "mime";
           foreverypart {
             replace "[replaced]";
           }
@@ -2150,9 +2157,9 @@ describe('Core Sieve tests (RFC 5228 Section 5)', () => {
 
         await assert.rejects(
           () => executeScript(script, message),
-          'expected using foreverypart/replace without requiring them to be ' +
-            'an error per RFC 5703, but the engine only checks capabilities ' +
-            'at require-time and executes the commands unguarded'
+          'expected foreverypart/replace used with no require statement to be ' +
+            'an error, but the engine only checks capabilities at require-time ' +
+            'and executes the commands unguarded'
         );
       });
     });

--- a/test/sieve/engine.js
+++ b/test/sieve/engine.js
@@ -2118,5 +2118,43 @@ describe('Core Sieve tests (RFC 5228 Section 5)', () => {
         );
       });
     });
+
+    describe('capability enforcement at execution time', () => {
+      it('should reject foreverypart/replace used without being required', async () => {
+        // RFC 5703 Sections 3 and 5 require that "foreverypart" and "replace"
+        // be declared in a require statement before the commands are used.
+        // Capability enforcement here happens only in processRequires(), which
+        // walks the strings literally listed in require; the command dispatch
+        // for foreverypart and replace has no hasCapability() guard at all.
+        // So omitting the declaration - which is what a script must do today
+        // to avoid the "Unsupported capability" rejection, since those strings
+        // are registered nowhere - lets the commands run anyway.
+        //
+        // The two failures are inverses of each other: a spec-compliant script
+        // is rejected, while this spec-violating one is accepted.
+        const script = `
+          require "mime";
+          foreverypart {
+            replace "[replaced]";
+          }
+        `;
+        const message = createMimeMessage([
+          {
+            contentType: 'image/png',
+            headers: { 'content-id': '<img1@example.com>' },
+            body: 'binarydata',
+            encoding: 'base64',
+            charset: false
+          }
+        ]);
+
+        await assert.rejects(
+          () => executeScript(script, message),
+          'expected using foreverypart/replace without requiring them to be ' +
+            'an error per RFC 5703, but the engine only checks capabilities ' +
+            'at require-time and executes the commands unguarded'
+        );
+      });
+    });
   });
 });

--- a/test/sieve/filter-handler.js
+++ b/test/sieve/filter-handler.js
@@ -232,6 +232,34 @@ describe('Sieve Filter Handler', () => {
     });
   });
 
+  describe('RFC 5703 capability registration', () => {
+    it('should accept a script that requires foreverypart/replace', async () => {
+      // The engine implements these commands (executeForeverypart,
+      // executeReplace), but the capability strings 'foreverypart', 'replace',
+      // 'extracttext' and 'enclose' are absent from all three capability
+      // lists: DEFAULT_CAPABILITIES and EXTENDED_CAPABILITIES in engine.js,
+      // and SUPPORTED_CAPABILITIES in filter-handler.js. processRequires()
+      // throws on any capability it cannot find, so a script that declares
+      // these extensions the way RFC 5703 Sections 3 and 5 require is
+      // rejected outright, before any condition is evaluated.
+      //
+      // Asserting on the absence of a throw rather than on a resulting action:
+      // executeScript() propagates the capability error as an exception, so
+      // the script never reaches the point of producing actions at all.
+      const script = `
+        require ["foreverypart", "mime", "replace"];
+        keep;
+      `;
+
+      await assert.doesNotReject(
+        () => handler.executeScript(script, createMessage(), {}),
+        'expected a script declaring foreverypart/replace to be accepted, but ' +
+          'those capability strings are registered nowhere, so processRequires() ' +
+          'throws "Unsupported capability: foreverypart"'
+      );
+    });
+  });
+
   describe('Vacation handling', () => {
     it('should send auto-reply', async () => {
       const result = {

--- a/test/sieve/integration-unit.js
+++ b/test/sieve/integration-unit.js
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) Forward Email LLC
+ * SPDX-License-Identifier: BUSL-1.1
+ *
+ * Sieve Integration Unit Tests
+ *
+ * These are node:test unit tests for pure helpers on SieveIntegration that
+ * do not require database connectivity (compare test/sieve/mx-integration.js).
+ * For full integration tests with the database, see test/sieve/integration.js
+ * (AVA), which needs the complete MX/IMAP/SQLite harness.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { Buffer } = require('node:buffer');
+
+const { SieveIntegration } = require('../../helpers/sieve/integration');
+
+// A long boundary of the shape Microsoft Exchange Online generates. Real
+// Exchange boundaries are long enough that the `boundary=` parameter is
+// routinely folded onto an RFC 5322 continuation line, which is what makes
+// the folded variant below the common case rather than an edge case.
+const BOUNDARY = '_004_AS8P194MB1974EXAMPLEBOUNDARY_';
+
+const IMAGE_BODY =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YA';
+
+/**
+ * Build a multipart/related message with an inline image part.
+ *
+ * @param {Object} options
+ * @param {boolean} options.folded - fold the top-level boundary parameter
+ *   onto a continuation line (Exchange Online style) instead of keeping the
+ *   whole Content-Type on one physical line
+ * @returns {Buffer} raw message
+ */
+function createRelatedMessage({ folded }) {
+  const topContentType = folded
+    ? `Content-Type: multipart/related;\r\n` +
+      `\tboundary="${BOUNDARY}";\r\n` +
+      `\ttype="multipart/alternative"`
+    : `Content-Type: multipart/related; boundary="${BOUNDARY}"; type="multipart/alternative"`;
+
+  return Buffer.from(
+    `From: sender@example.com\r\n` +
+      `To: recipient@example.com\r\n` +
+      `Subject: Test\r\n` +
+      `MIME-Version: 1.0\r\n` +
+      `${topContentType}\r\n` +
+      `\r\n` +
+      `--${BOUNDARY}\r\n` +
+      `Content-Type: text/plain; charset="utf-8"\r\n` +
+      `\r\n` +
+      `Hello.\r\n` +
+      `--${BOUNDARY}\r\n` +
+      `Content-Type: image/png; name="logo.png"\r\n` +
+      `Content-Transfer-Encoding: base64\r\n` +
+      `Content-ID: <img1>\r\n` +
+      `Content-Disposition: inline; filename="logo.png"\r\n` +
+      `\r\n` +
+      `${IMAGE_BODY}\r\n` +
+      `--${BOUNDARY}--\r\n`,
+    'utf8'
+  );
+}
+
+describe('Sieve Integration (unit)', () => {
+  describe('applyReplaceActions boundary detection (RFC 5322 folding)', () => {
+    // The image is the second child part, which maps to split segment 2
+    // (segment 0 is the preamble/top-level headers, segment 1 is text/plain).
+    const replaceActions = [
+      { partIndex: 2, replacement: '[image removed by filter]', mime: false }
+    ];
+
+    it('should apply replace when the top-level boundary is folded', () => {
+      const integration = new SieveIntegration({});
+      const raw = createRelatedMessage({ folded: true });
+      const result = integration.applyReplaceActions(raw, replaceActions);
+
+      // applyReplaceActions() locates the boundary with
+      //   /content-type:[^\r\n]*boundary="?([^"\s;]+)"?/i
+      // and [^\r\n]* cannot cross a line break. RFC 5322 Section 2.2.3 allows
+      // header field bodies to be folded onto continuation lines, and Exchange
+      // Online does exactly that for multipart/related because its boundary
+      // strings are long. The match therefore returns null and the function
+      // silently returns the message unchanged, so replace becomes a no-op for
+      // this very common class of message.
+      assert.notStrictEqual(
+        Buffer.compare(raw, result),
+        0,
+        'expected replace to rewrite the MIME part, but the message came back ' +
+          'byte-identical because the boundary regex cannot match a folded ' +
+          'Content-Type header'
+      );
+      assert.ok(
+        result.toString('utf8').includes('[image removed by filter]'),
+        'expected the replacement text to be present in the rewritten message'
+      );
+      assert.ok(
+        !result.toString('utf8').includes(IMAGE_BODY),
+        'expected the original image body to be gone after replace'
+      );
+    });
+
+    it('should apply replace when the top-level boundary is not folded', () => {
+      // Control: identical message, boundary on a single physical line. This
+      // passes today, which is what isolates folding specifically as the
+      // trigger for the failure above.
+      const integration = new SieveIntegration({});
+      const raw = createRelatedMessage({ folded: false });
+      const result = integration.applyReplaceActions(raw, replaceActions);
+
+      assert.notStrictEqual(Buffer.compare(raw, result), 0);
+      assert.ok(result.toString('utf8').includes('[image removed by filter]'));
+      assert.ok(!result.toString('utf8').includes(IMAGE_BODY));
+    });
+  });
+
+  describe('parseMimeTree header unfolding (RFC 5322 Section 2.2.3)', () => {
+    it('should unfold header continuation lines instead of creating bogus keys', async () => {
+      const integration = new SieveIntegration({});
+      const raw = Buffer.from(
+        `From: sender@example.com\r\n` +
+          `To: recipient@example.com\r\n` +
+          `Subject: Test\r\n` +
+          `MIME-Version: 1.0\r\n` +
+          `Content-Type: multipart/related; boundary="${BOUNDARY}"\r\n` +
+          `\r\n` +
+          `--${BOUNDARY}\r\n` +
+          `Content-Type: image/png; name="logo.png"\r\n` +
+          `Content-ID: <img1>\r\n` +
+          `Content-Disposition: inline; filename="logo.png";\r\n` +
+          `\tcreation-date="Mon, 21 Jul 2026 10:00:00 GMT"\r\n` +
+          `\r\n` +
+          `${IMAGE_BODY}\r\n` +
+          `--${BOUNDARY}--\r\n`,
+        'utf8'
+      );
+
+      const parts = await integration.parseMimeTree(raw);
+      const imagePart = parts.find((part) =>
+        String(part.contentType).startsWith('image/')
+      );
+      assert.ok(imagePart, 'expected to find the image/png part');
+
+      // parseMimeTree() splits chunk.getHeaders() on /\r?\n/ and treats every
+      // physical line as a complete header, doing line.indexOf(':') per line.
+      // A folded continuation line therefore becomes its own header, and the
+      // colon inside the timestamp ("10:00:00") is misread as the separator,
+      // yielding a bogus key of `creation-date="mon, 21 jul 2026 10`.
+      //
+      // Note this does not by itself break :type extraction: the
+      // content-disposition value keeps its leading `inline` token, which
+      // precedes the fold. It will however corrupt any read of a folded
+      // parameter.
+      const bogusKeys = Object.keys(imagePart.headers).filter((name) =>
+        name.startsWith('creation-date=')
+      );
+      assert.deepStrictEqual(
+        bogusKeys,
+        [],
+        `expected no bogus header key from the folded continuation line, got ${JSON.stringify(
+          bogusKeys
+        )}`
+      );
+      assert.ok(
+        imagePart.headers['content-disposition'].includes('creation-date'),
+        'expected the folded continuation line to be joined onto the ' +
+          'content-disposition value'
+      );
+    });
+  });
+
+  describe('engine construction from configured extensions', () => {
+    it('should pass configured enabledExtensions through to the engine', () => {
+      // NOTE: this documents a latent configuration trap, not a live defect.
+      // The engine built here is currently DEAD CODE: processMessage()
+      // constructs a fresh SieveFilterHandler and executes scripts through
+      // *its* engine, which is built by createEngine() with a correctly-keyed
+      // `capabilities` option. SieveIntegration's `this.engine` is assigned in
+      // the constructor and never read again.
+      //
+      // The mismatch is still worth fixing, because anyone who later wires
+      // `this.engine` up will silently get none of the configured extensions:
+      // the constructor passes `extensions:` while SieveEngine's constructor
+      // reads only `options.capabilities`, so the configured list is dropped
+      // and capabilities fall back to the bare DEFAULT_CAPABILITIES set.
+      const integration = new SieveIntegration({});
+      assert.ok(
+        integration.config.enabledExtensions.includes('mime'),
+        'precondition: mime is in the default enabledExtensions list'
+      );
+
+      assert.ok(
+        integration.engine.capabilities.has('mime'),
+        'expected the engine to receive the configured enabledExtensions, but ' +
+          'SieveIntegration passes them as `extensions` while SieveEngine ' +
+          'reads only `capabilities`, so the list is silently discarded'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Failing tests demonstrating four further Sieve bugs found while re-testing the RFC 5703 fix from #548 / 8665211b against the real delivery path. **These are reproductions, not fixes** — same posture as #549; I'm not confident enough in `engine.js`/`integration.js` internals to fix them safely, and bug 1 in particular has a design question (which of the three capability lists is authoritative) that needs a maintainer decision first.

Full analysis, RFC citations, and execution output are in #556.

### What the tests cover

| Test | File | Bug |
|---|---|---|
| `require ["foreverypart","mime","replace"]` is rejected | `test/sieve/filter-handler.js` | `foreverypart`/`replace`/`extracttext`/`enclose` are in none of the three capability lists, so a spec-compliant script dies with `Unsupported capability` before any condition runs |
| `foreverypart`/`replace` execute with no `require` at all | `test/sieve/engine.js` | Capabilities are enforced only in `processRequires()`; command dispatch has no guard, so the inverse of the above is also broken |
| `replace` on a folded top-level boundary | `test/sieve/integration-unit.js` | `applyReplaceActions()`'s `/content-type:[^\r\n]*boundary=.../i` can't cross a fold, so it silently returns the message unchanged — this is what Exchange Online emits |
| folded header continuation lines | `test/sieve/integration-unit.js` | `parseMimeTree()` treats each physical line as a header, turning a folded param into a garbage key |
| `SieveIntegration` engine ignores configured extensions | `test/sieve/integration-unit.js` | Constructor passes `extensions:` where the engine reads `capabilities:` — latent config trap, documented in-test as dead code, **not** a live defect |

The folded-boundary test ships with an unfolded control that passes today, so the diff shows folding specifically is the trigger. All fixtures are synthetic.

The three integration-layer tests go in a **new** `test/sieve/integration-unit.js` rather than the existing `test/sieve/integration.js`, because the latter is an AVA suite requiring the full MX/IMAP/SQLite harness. The new file follows the precedent of `test/sieve/mx-integration.js`, the existing `node:test` unit counterpart. Happy to relocate if you'd prefer them elsewhere.

### On `mime` as an umbrella capability — please read before reviewing the enforcement test

There is an unresolved design question here that I have deliberately not pre-judged, because it changes what the correct fix looks like.

RFC 5703 defines **distinct** capability strings per command: `foreverypart` (§3), `mime` (§4), `replace` (§5), `enclose` (§6), `extracttext` (§7). Read strictly, each must be declared before its command is used. But this codebase treats `mime` as an umbrella covering all five: 26 existing tests in `test/sieve/engine.js` drive `foreverypart` behind `require ["mime", "variables"]` alone, 8665211b's own tests do the same, and `app/views/faq/index.md:2850` documents `mime` as "✅ Full — `foreverypart`, `break`, `extracttext`, `replace`, `enclose` commands".

Both readings are defensible, and picking one is your call, not mine. So the enforcement test in `test/sieve/engine.js` uses a script with **no `require` statement whatsoever**, which is invalid under either reading. An earlier draft of this PR asserted that `require "mime"; foreverypart {...}` should throw — that would have contradicted 26 of your own tests and quietly taken a side on this question, so I changed it (see the last commit on this branch).

The practical consequence for bug 1: if `mime` is meant to be the umbrella, the fix is to resolve the four command names through it; if the strict reading is intended, all five strings need registering and the 26 existing tests would need `require` lines updated. Question 1 in #556 asks which you prefer.

### Notes

- Assertions deliberately avoid `keep` as a success signal — Sieve's implicit keep makes that false-pass when a condition never matched (the trap hit during #549).
- The last test exercises a code path that is currently unreachable; it's included to pin down a silent-config-loss trap for whoever wires it up, and the in-test comment says so explicitly. Happy to drop it if you'd rather not have a test against dead code.
- An earlier theory that this key mismatch broke `vacation`/`variables`/`editheader` for all live scripts turned out to be **wrong** — `hasCapability()` ORs in `EXTENDED_CAPABILITIES`, and live scripts run through `SieveFilterHandler`'s own correctly-built engine. The issue documents this as ruled out so nobody re-investigates it.

### Test results

```
NODE_PATH=... node --test test/sieve/engine.js test/sieve/filter-handler.js test/sieve/integration-unit.js test/sieve/parser.js test/sieve/mx-integration.js test/sieve/extensions.js
```

```
ℹ tests 328
ℹ pass 323
ℹ fail 5
```

Baseline on `master` for the same files is 322 tests / 322 pass / 0 fail. The 5 failures are exactly the new tests; the 6th addition (the unfolded-boundary control) passes. No pre-existing test changes behavior.

\* _The original issue and this PR  were researched and written in part by Claude, but I have verified the claims and validated the code as much as I am able to (being new to this codebase)._
